### PR TITLE
(fix)profile serializer

### DIFF
--- a/Server/profiles/models.py
+++ b/Server/profiles/models.py
@@ -53,5 +53,5 @@ class TeamProfile(models.Model):
     image = models.ImageField(upload_to='group', null=True, blank=True)
     stack = models.ManyToManyField('tags.Tag')
     created_at = models.DateTimeField(auto_now_add=True)
-    members = models.ManyToManyField('members.Member', db_constraint=False)
+    members = models.ManyToManyField('members.Member', db_constraint=False, related_name="fixmember")
     waiting_members = models.ManyToManyField(WaitingForMember,db_constraint=False, related_name="teammember")

--- a/Server/profiles/serializers.py
+++ b/Server/profiles/serializers.py
@@ -63,7 +63,9 @@ class ProfileSerializer(serializers.ModelSerializer):
         )
     def get_teamprofiles(self,obj):
         id = obj.id
-        teamprofiles = TeamProfile.objects.filter(user=id)
+        member = Member.objects.get(member=id)
+        teamprofiles = TeamProfile.objects.filter(members=member)
+
         serializer = TeamProfileReadSerializer(teamprofiles, many=True)
         return serializer.data
 


### PR DESCRIPTION
자신의 만든 팀프로필만 프로필페이지에 넘어오고있어서  자신이 만든 팀프로필이 아니더라도 멤버로 속해있는 팀프로필까지 반환 될수 있도록 변경하였습니다.